### PR TITLE
Fix parsing the table section

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -324,10 +324,10 @@ func (p *parser) parseTableSection(base *section) (*SectionTable, error) {
 	s := SectionTable{section: base}
 
 	err := p.loopCount(func() error {
-		var e MemoryType
+		var e TableType
 
-		if err := p.parseResizableLimits(&e.Limits); err != nil {
-			return fmt.Errorf("read memory resizable limits: %v", err)
+		if err := p.parseTableType(&e); err != nil {
+			return fmt.Errorf("read table type: %v", err)
 		}
 
 		s.Entries = append(s.Entries, e)
@@ -622,6 +622,18 @@ func (p *parser) parseResizableLimits(l *ResizableLimits) error {
 	}
 	if err := readVarUint32(p.r, &l.Maximum); err != nil {
 		return fmt.Errorf("maximum: %v", err)
+	}
+	return nil
+}
+
+func (p *parser) parseTableType(t *TableType) error {
+	refType, err := readByte(p.r)
+	if err != nil {
+		return fmt.Errorf("read table type limits: %v", err)
+	}
+	t.ElemType = int8(refType)
+	if err := p.parseResizableLimits(&t.Limits); err != nil {
+		return fmt.Errorf("read memory resizable limits: %v", err)
 	}
 	return nil
 }

--- a/sections.go
+++ b/sections.go
@@ -152,7 +152,7 @@ type SectionFunction struct {
 //
 // https://github.com/WebAssembly/design/blob/master/Semantics.md#table
 type SectionTable struct {
-	Entries []MemoryType
+	Entries []TableType
 
 	*section
 }

--- a/testdata/golden/helloworld-04.json
+++ b/testdata/golden/helloworld-04.json
@@ -1,9 +1,10 @@
 {
 	"Entries": [
 		{
+			"ElemType": 112,
 			"Limits": {
-				"Initial": 0,
-				"Maximum": 5682
+				"Initial": 5682,
+				"Maximum": 0
 			}
 		}
 	]


### PR DESCRIPTION
The table type was not correctly parsed: the reftype byte wasn't read.
This happened to allow the test to be parsed, but slightly incorrectly. Other wasm files cannot be parsed.

https://webassembly.github.io/spec/core/binary/types.html#table-types

I think this will fix #3 and maybe also #2.