### PR TITLE
Add Eval function to evaluate simple expressions

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1,0 +1,38 @@
+package wasm
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+// Eval tries to evaluate the (constant) expression in the buffer. It returns
+// the evaluation stack at the end of the sequence or an error, if there was
+// one.
+func Eval(r *bytes.Buffer) ([]interface{}, error) {
+	// Right now, this is only meant to parse very simple expressions like the
+	// one used for the start offset of a data segment (which is an expression).
+	var stack []interface{}
+	for {
+		b, err := r.ReadByte()
+		if err == io.EOF {
+			return nil, io.ErrUnexpectedEOF
+		}
+		if b == 0x0B { // end
+			// End of expression.
+			break
+		}
+		switch b {
+		case 0x41: // i32.const
+			var n int32
+			err := readVarInt32(r, &n)
+			if err != nil {
+				return nil, err
+			}
+			stack = append(stack, n)
+		default:
+			return nil, fmt.Errorf("unknown opcode: 0x%02X", b)
+		}
+	}
+	return stack, nil
+}

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,0 +1,30 @@
+package wasm
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestEval(t *testing.T) {
+	tests := []struct {
+		buf    []byte
+		result []interface{}
+	}{
+		{[]byte{0x41, 0x80, 0x80, 0x04, 0x0B}, []interface{}{int32(0x10000)}},
+		{[]byte{0x41, 0xA0, 0xFE, 0x04, 0x0B}, []interface{}{int32(0x13f20)}},
+		{[]byte{0x0B}, nil},
+	}
+
+	for i, tc := range tests {
+		r := bytes.NewBuffer(tc.buf)
+		result, err := Eval(r)
+		if err != nil {
+			t.Errorf("failed to run test %d: %w", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(result, tc.result) {
+			t.Errorf("expected %v but got %v", tc.result, result)
+		}
+	}
+}


### PR DESCRIPTION
This is especially useful to parse the `Offset` field of a `wasm.DataSegment`, which is usually just a constant.